### PR TITLE
Initial support for selectors via delegates

### DIFF
--- a/src/main/kotlin/com/github/epadronu/balin/core/LazyExpectedConditions.kt
+++ b/src/main/kotlin/com/github/epadronu/balin/core/LazyExpectedConditions.kt
@@ -1,0 +1,30 @@
+package com.github.epadronu.balin.core
+
+import org.openqa.selenium.By
+import org.openqa.selenium.WebElement
+import org.openqa.selenium.support.ui.ExpectedCondition
+import org.openqa.selenium.support.ui.ExpectedConditions
+
+class LazyConditions {
+    companion object {
+        val CLICKABLE = ::isClickable
+
+        private fun isClickable(by: By, page: Page, withElement: ((WebElement) -> WebElement)? = null) = lazy {
+            if(withElement != null) {
+                throw IllegalArgumentException("withElement block not supported when using LazyConditions.CLICKABLE")
+            }
+            page.waitFor { ExpectedConditions.elementToBeClickable(by) } }
+
+        val IS_PRESENT = ::isPresent
+
+        private fun isPresent(by: By, page: Page, withElement: ((WebElement) -> WebElement)? = null) = lazy {
+            page.waitFor {
+                ExpectedCondition { webDriver ->
+                    val webElement = webDriver?.findElement(by)
+                    if(withElement != null) webElement?.let(withElement) else webElement
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/com/github/epadronu/balin/core/Page.kt
+++ b/src/main/kotlin/com/github/epadronu/balin/core/Page.kt
@@ -19,8 +19,11 @@ package com.github.epadronu.balin.core
 /* ***************************************************************************/
 
 /* ***************************************************************************/
+import org.openqa.selenium.By
 import org.openqa.selenium.SearchContext
 import org.openqa.selenium.WebElement
+import kotlin.reflect.KFunction
+
 /* ***************************************************************************/
 
 /* ***************************************************************************/
@@ -102,5 +105,30 @@ abstract class Page(val browser: Browser) : ClickAndNavigateSupport,
     internal fun verifyAt(): Boolean {
         return at(browser)
     }
+
+    fun xpath(expression: String,
+              withElement: ((WebElement) -> WebElement)? = null,
+              waitFor: (By, Page, ((WebElement) -> WebElement)?) -> Lazy<WebElement> = LazyConditions.CLICKABLE) : Lazy<WebElement> {
+        val xpath: By = By.xpath(expression)
+        return waitFor(xpath, this, withElement)
+
+    }
+
+    fun cssSelector(expression: String,
+                    withElement: ((WebElement) -> WebElement)? = null,
+                    waitFor: (By, Page, ((WebElement) -> WebElement)?) -> Lazy<WebElement> = LazyConditions.CLICKABLE) : Lazy<WebElement> {
+        val by: By = By.cssSelector(expression)
+        return waitFor(by, this, withElement)
+    }
+
+
+    fun className(expression: String,
+                    withElement: ((WebElement) -> WebElement)? = null,
+                    waitFor: (By, Page, ((WebElement) -> WebElement)?) -> Lazy<WebElement> = LazyConditions.CLICKABLE) : Lazy<WebElement> {
+        val by: By = By.className(expression)
+        return waitFor(by, this, withElement)
+    }
+
+
 }
 /* ***************************************************************************/

--- a/src/test/kotlin/com/github/epadronu/balin/examples/helloworld/HelloWorld.kt
+++ b/src/test/kotlin/com/github/epadronu/balin/examples/helloworld/HelloWorld.kt
@@ -16,17 +16,23 @@
 
 /* ***************************************************************************/
 package com.github.epadronu.balin.examples.helloworld
+
 /* ***************************************************************************/
 
 /* ***************************************************************************/
 import com.github.epadronu.balin.core.Browser
+import com.github.epadronu.balin.core.LazyConditions
+import com.github.epadronu.balin.core.LazyConditions.Companion.CLICKABLE
+import com.github.epadronu.balin.core.LazyConditions.Companion.IS_PRESENT
 import com.github.epadronu.balin.core.Page
 import org.openqa.selenium.By
-import org.openqa.selenium.support.ui.ExpectedCondition
+import org.openqa.selenium.NotFoundException
+import org.openqa.selenium.support.ui.ExpectedConditions
 import org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable
 import org.testng.Assert
 import org.testng.annotations.BeforeClass
 import org.testng.annotations.Test
+
 /* ***************************************************************************/
 
 /* ***************************************************************************/
@@ -38,11 +44,9 @@ class IndexPage(browser: Browser) : Page(browser) {
         title == "Kotlin Programming Language"
     }
 
-    private val tryItButton by lazy {
-        waitFor { elementToBeClickable(By.xpath("//a[@class='nav-item' and contains(text(),'Try Online')]")) }
-    }
+    val tryItButton by xpath("//a[@class='nav-item' and contains(text(),'Try Online')]")
 
-    fun goToTryItPage(): TryItPage = tryItButton.click(::TryItPage)
+    fun goToTryItPage() = tryItButton.click(::TryItPage)
 }
 
 class TryItPage(browser: Browser) : Page(browser) {
@@ -51,19 +55,10 @@ class TryItPage(browser: Browser) : Page(browser) {
         title.contains("Kotlin Playground")
     }
 
-    private val consoleOutput by lazy {
-        waitFor {
-            ExpectedCondition { webDriver ->
-                webDriver?.findElement(By.cssSelector(".code-output"))?.let { webElement ->
-                    if (webElement.text.isEmpty()) null else webElement
-                }
-            }
-        }
-    }
+    private val consoleOutput by cssSelector(".code-output", waitFor = IS_PRESENT,
+            withElement ={ if (it.text.isEmpty()) throw NotFoundException("Test is still empty") else it } )
 
-    private val runButton by lazy {
-        waitFor { elementToBeClickable(By.className("wt-button_mode_primary")) }
-    }
+    private val runButton by className("wt-button_mode_primary")
 
     fun runHelloWorld(): String {
         runButton.click()


### PR DESCRIPTION
By using delegate properties, I would like to remove a lot of the noise when creating page objects.

This isn't complete, but it gives you an idea of how I would like to improve the syntax for creating page objects.

Compare the HelloWorld `runButton` and `tryItButton` syntax as an example.

The `consoleOutput` is the most complex example, since it changes what the `waitFor` from the default `CLICKABLE` to the `IS_PRESENT` condition and also does additional stuff with the element.

I don't love duplication in the so I'm considering alternative strategies. I look forward to your feedback.